### PR TITLE
Add GitHub Actions prebuild workflow

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -1,0 +1,78 @@
+name: Build and Publish Prebuilt Binaries
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Prebuild binary
+        run: pnpm --filter @validators-dao/solana-entry-decoder exec napi prebuild --release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: prebuild-${{ matrix.os }}-node${{ matrix.node }}
+          path: napi/solana-entry-decoder/prebuilds/**
+
+  publish:
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
+          cache: 'pnpm'
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          pattern: prebuild-*
+          path: napi/solana-entry-decoder/prebuilds
+          merge-multiple: true
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish to npm
+        run: pnpm --filter @validators-dao/solana-entry-decoder publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- add workflow to prebuild `napi` binaries for macOS, Linux and Windows
- publish npm package using gathered artifacts

## Testing
- `cargo check` *(fails: unsuccessful tunnel)*
- `pnpm --version` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6842ece2c614832488a8e301e74af04b