### PR TITLE
feat: log API docs URL on server startup

### DIFF
--- a/temp-release/trade-app/src/main.rs
+++ b/temp-release/trade-app/src/main.rs
@@ -122,6 +122,7 @@ async fn main() -> Result<(), anyhow::Error> {
             let router = build_router(state, rpc, api_token);
             let addr = SocketAddr::from(([0, 0, 0, 0], port));
             log::info!("API server listening on http://{}", addr);
+            println!("📖 API docs: http://{}/docs", addr);
             let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
             axum::serve(listener, router).await.unwrap();
         })


### PR DESCRIPTION
## Summary
- Print \`📖 API docs: http://<addr>/docs\` to stdout when the trade-app API server starts, so the docs URL is easy to find in terminal output.

## Test plan
- [x] \`cargo build\` succeeds
- [ ] Start trade-app locally and confirm the docs URL line appears after \`API server listening on…\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)