### PR TITLE
feat: i18n for Discord/notification messages (TRADE_APP_LANG)

### DIFF
--- a/temp-release/trade-app/Cargo.toml
+++ b/temp-release/trade-app/Cargo.toml
@@ -10,6 +10,10 @@ publish = false
 name = "trade-app"
 path = "src/main.rs"
 
+[[bin]]
+name = "notify-test"
+path = "src/bin/notify_test.rs"
+
 [dependencies]
 anyhow = "1.0.62"
 axum = "0.8"

--- a/temp-release/trade-app/src/api.rs
+++ b/temp-release/trade-app/src/api.rs
@@ -1,4 +1,5 @@
 use crate::state::{AppState, TradeAction, TradeLog};
+use crate::i18n;
 use crate::webhook::notify_discord;
 use axum::{
     extract::{Path, Query, Request, State},
@@ -336,7 +337,7 @@ async fn post_trade_start(State(ctx): State<ApiContext>, Query(query): Query<Sta
             Json(StartResponse {
                 started: true,
                 already_running: true,
-                message: "Trading already running.".to_string(),
+                message: i18n::trading_already_running(),
                 wallet_pubkey: Some(pubkey.to_string()),
                 balance_sol: Some(balance_sol),
             }),
@@ -344,12 +345,11 @@ async fn post_trade_start(State(ctx): State<ApiContext>, Query(query): Query<Sta
     }
 
     s.running = true;
-    let msg = format!(
-        "▶️ Trading started — wallet: {} | balance: {:.4} SOL | buy: {:.4} SOL | sell: {}x",
-        pubkey,
+    let msg = i18n::trading_started(
+        &pubkey.to_string(),
         balance_sol,
         buy_amount_lamports as f64 / 1e9,
-        s.config.sell_multiplier
+        s.config.sell_multiplier,
     );
     fire_notification(&mut s, &msg);
     (
@@ -370,7 +370,7 @@ async fn post_trade_stop(State(ctx): State<ApiContext>) -> impl IntoResponse {
     let mut s = ctx.state.write().await;
     s.running = false;
     let positions = s.active_position_count();
-    let msg = format!("⏹️ Trading stopped — active positions: {}", positions);
+    let msg = i18n::trading_stopped(positions);
     fire_notification(&mut s, &msg);
     Json(serde_json::json!({ "stopped": true }))
 }
@@ -502,7 +502,7 @@ async fn get_wallet(State(ctx): State<ApiContext>) -> impl IntoResponse {
 async fn post_grpc_start(State(ctx): State<ApiContext>) -> impl IntoResponse {
     let mut s = ctx.state.write().await;
     s.grpc_streaming = true;
-    let msg = "📡 gRPC streaming started — pool detection & notifications active".to_string();
+    let msg = i18n::grpc_started();
     fire_notification(&mut s, &msg);
     Json(serde_json::json!({ "grpc_streaming": true }))
 }
@@ -512,7 +512,7 @@ async fn post_grpc_start(State(ctx): State<ApiContext>) -> impl IntoResponse {
 async fn post_grpc_stop(State(ctx): State<ApiContext>) -> impl IntoResponse {
     let mut s = ctx.state.write().await;
     s.grpc_streaming = false;
-    let msg = "⏸️ gRPC streaming stopped — pool detection paused".to_string();
+    let msg = i18n::grpc_stopped();
     fire_notification(&mut s, &msg);
     Json(serde_json::json!({ "grpc_streaming": false }))
 }

--- a/temp-release/trade-app/src/bin/notify_test.rs
+++ b/temp-release/trade-app/src/bin/notify_test.rs
@@ -1,0 +1,93 @@
+//! Send all i18n notification templates to the configured Discord webhook.
+//!
+//! Reads `WEBHOOK_URL` and `TRADE_APP_LANG` from `.env`. Useful for verifying
+//! that Discord notifications render correctly in every language without
+//! running the full trading bot.
+//!
+//! Usage:
+//!   cargo run --bin notify-test
+//!   TRADE_APP_LANG=ja cargo run --bin notify-test
+//!   cargo run --bin notify-test -- all   # cycle through every language
+
+#[path = "../i18n.rs"]
+mod i18n;
+#[path = "../webhook.rs"]
+mod webhook;
+
+use webhook::notify_discord;
+
+async fn send_all(url: &str, label: &str) {
+    let pool = "8xQw5GQ3YMYVrnF4Ym1WbpQJ2aK7k2Qf3hJzXvD9mN1p";
+    let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    let tx = "5Uh3K1J4bD8Zz9tC7Qp2Nm3Xa1Rf6wGe4Vc9Ls7Tk2Bo8Yj";
+    let ts = chrono::Utc::now().to_rfc3339();
+
+    let header = format!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n🧪 **i18n notify-test** ({})", label);
+    notify_discord(url, &header).await;
+
+    notify_discord(url, &i18n::pool_qualified_log(pool, mint, 12.3456, &ts)).await;
+    notify_discord(url, &i18n::pool_qualified_webhook(pool, mint, 12.3456, &ts)).await;
+    notify_discord(url, &i18n::buy_confirmed(pool, mint, 0.0100, 1_234_567, tx)).await;
+    notify_discord(
+        url,
+        &i18n::retreat_burn(
+            pool, mint, "timeout 300s",
+            "🔴", "", -0.003210, -32.1,
+            0.0100, 0.006790, false,
+        ),
+    )
+    .await;
+    notify_discord(
+        url,
+        &i18n::trade_complete(
+            "🟢", pool, mint,
+            "+", 0.001234, 12.3,
+            0.0100, 0.011234, true,
+        ),
+    )
+    .await;
+    notify_discord(url, &i18n::sell_failed_onchain(pool, tx)).await;
+    notify_discord(url, &i18n::sell_tx_unknown(pool, tx)).await;
+    notify_discord(url, &i18n::sell_send_failed(pool, "RpcError: transaction simulation failed")).await;
+    notify_discord(url, &i18n::error_notify(pool, mint, "Fetch pool failed after 8 retries")).await;
+    notify_discord(url, &i18n::position_restored(1_234_567, 9_876_543)).await;
+    notify_discord(
+        url,
+        &i18n::trading_started("Hx9...AbC", 1.2345, 0.0100, 1.1),
+    )
+    .await;
+    notify_discord(url, &i18n::trading_stopped(2)).await;
+    notify_discord(url, &i18n::grpc_started()).await;
+    notify_discord(url, &i18n::grpc_stopped()).await;
+    notify_discord(url, &i18n::trading_already_running()).await;
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    dotenv::dotenv().ok();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let url = std::env::var("WEBHOOK_URL")
+        .map_err(|_| anyhow::anyhow!("WEBHOOK_URL is not set in environment"))?;
+
+    let args: Vec<String> = std::env::args().collect();
+    let cycle_all = args.iter().any(|a| a == "all");
+
+    if cycle_all {
+        // Override TRADE_APP_LANG per iteration — requires separate processes
+        // because i18n::init_from_env stores the lang in a OnceLock. So here
+        // we just print guidance and run the currently-configured lang once.
+        log::warn!(
+            "`all` mode: OnceLock prevents switching lang mid-process. \
+             Run once per language instead, e.g.:\n  \
+             for L in en ja zh ru vi; do TRADE_APP_LANG=$L cargo run --bin notify-test; done"
+        );
+    }
+
+    i18n::init_from_env();
+    let label = format!("{:?}", i18n::lang());
+    log::info!("Sending {} notifications to webhook…", label);
+    send_all(&url, &label).await;
+    log::info!("Done.");
+    Ok(())
+}

--- a/temp-release/trade-app/src/engine.rs
+++ b/temp-release/trade-app/src/engine.rs
@@ -1,5 +1,6 @@
 use crate::state::{persist_trade_log_to_redis, AppState, Position, PositionStatus, TradeAction, TradeLog};
 use crate::wallet::keypair_from_bytes;
+use crate::i18n;
 use crate::webhook::notify_discord;
 use chrono::Utc;
 use log::{error, info, warn};
@@ -239,26 +240,14 @@ pub async fn handle_new_pool(
     // Notify via webhook + record in logs
     {
         let mut s = state.write().await;
-        let msg = format!(
-            "🆕 Pool qualified — Pool: {} | Base Mint: {} | SOL reserves: {:.4} | Time: {}",
-            pool_address,
-            base_mint,
-            base_vault_balance as f64 / 1e9,
-            Utc::now().to_rfc3339()
-        );
-        s.push_notification(pool_address, base_mint, msg.clone());
+        let pool_str = pool_address.to_string();
+        let mint_str = base_mint.to_string();
+        let sol = base_vault_balance as f64 / 1e9;
+        let ts = Utc::now().to_rfc3339();
+        let msg = i18n::pool_qualified_log(&pool_str, &mint_str, sol, &ts);
+        s.push_notification(pool_address, base_mint, msg);
         if let Some(url) = &webhook_url {
-            let discord_msg = format!(
-                "🆕 **Pool Qualified for Trade**\n\
-                 Pool: `{}`\n\
-                 Base Mint: `{}`\n\
-                 SOL Reserves: `{:.4} SOL`\n\
-                 Timestamp: {}",
-                pool_address,
-                base_mint,
-                base_vault_balance as f64 / 1e9,
-                Utc::now().to_rfc3339()
-            );
+            let discord_msg = i18n::pool_qualified_webhook(&pool_str, &mint_str, sol, &ts);
             let url = url.clone();
             tokio::spawn(async move {
                 notify_discord(&url, &discord_msg).await;
@@ -487,16 +476,12 @@ pub async fn handle_new_pool(
                     }
                     // Discord: Buy Confirmed
                     if let Some(url) = &webhook_url {
-                        let discord_msg = format!(
-                            "✅ **Buy Confirmed**\n\
-                             Pool: `{}`\n\
-                             Base Mint: `{}`\n\
-                             Amount: `{:.4} SOL`\n\
-                             Tokens: `{}`\n\
-                             Tx: `{}`",
-                            pool_address, base_mint,
+                        let discord_msg = i18n::buy_confirmed(
+                            &pool_address.to_string(),
+                            &base_mint.to_string(),
                             buy_amount_lamports as f64 / 1e9,
-                            final_amount, sig_str,
+                            final_amount,
+                            &sig_str,
                         );
                         let url = url.clone();
                         tokio::spawn(async move { notify_discord(&url, &discord_msg).await });
@@ -770,19 +755,17 @@ pub async fn check_and_sell_positions(
             let profit_sign = if profit_sol >= 0.0 { "+" } else { "" };
             let emoji = if profit_sol >= 0.0 { "🟢" } else { "🔴" };
             if let Some(url) = webhook_url_close {
-                let discord_msg = format!(
-                    "⚠️ **Retreat Burn**\n\
-                     Pool: `{}`\n\
-                     Base Mint: `{}`\n\
-                     Reason: `{}`\n\
-                     {} **{}{:.6} SOL ({}{:.1}%)**\n\
-                     Buy: `{:.6} SOL` → Realized: `{:.6} SOL`\n\
-                     ATA: {}",
-                    position.pool, position.base_mint,
-                    retreat_reason,
-                    emoji, profit_sign, profit_sol, profit_sign, profit_pct,
-                    buy_sol, sell_sol,
-                    if close_ok { "Closed ✅" } else { "Close failed ⚠️" },
+                let discord_msg = i18n::retreat_burn(
+                    &position.pool.to_string(),
+                    &position.base_mint.to_string(),
+                    &retreat_reason,
+                    emoji,
+                    profit_sign,
+                    profit_sol,
+                    profit_pct,
+                    buy_sol,
+                    sell_sol,
+                    close_ok,
                 );
                 tokio::spawn(async move { notify_discord(&url, &discord_msg).await });
             }
@@ -943,18 +926,16 @@ pub async fn check_and_sell_positions(
                             );
 
                             if let Some(url) = webhook_url_final {
-                                let discord_msg = format!(
-                                    "{} **Trade Complete**\n\
-                                     Pool: `{}`\n\
-                                     Base Mint: `{}`\n\
-                                     💰 **{}{:.6} SOL ({}{:.1}%)**\n\
-                                     Buy: `{:.6} SOL` → Sell: `{:.6} SOL`\n\
-                                     ATA: {}",
+                                let discord_msg = i18n::trade_complete(
                                     emoji,
-                                    position.pool, position.base_mint,
-                                    profit_sign, profit_sol, profit_sign, profit_pct,
-                                    buy_sol, sell_sol,
-                                    if close_ok { "Closed ✅" } else { "Close failed ⚠️" },
+                                    &position.pool.to_string(),
+                                    &position.base_mint.to_string(),
+                                    profit_sign,
+                                    profit_sol,
+                                    profit_pct,
+                                    buy_sol,
+                                    sell_sol,
+                                    close_ok,
                                 );
                                 tokio::spawn(async move { notify_discord(&url, &discord_msg).await });
                             }
@@ -984,10 +965,7 @@ pub async fn check_and_sell_positions(
                             s.webhook_url.clone()
                         };
                         if let Some(url) = webhook_url_sell {
-                            let discord_msg = format!(
-                                "❌ **Sell Failed (on-chain)**\nPool: `{}`\nTx: `{}`\nPosition reset to Active for retry.",
-                                position.pool, sig_str
-                            );
+                            let discord_msg = i18n::sell_failed_onchain(&position.pool.to_string(), &sig_str);
                             tokio::spawn(async move { notify_discord(&url, &discord_msg).await });
                         }
                     }
@@ -1002,10 +980,7 @@ pub async fn check_and_sell_positions(
                             s.webhook_url.clone()
                         };
                         if let Some(url) = webhook_url_sell {
-                            let discord_msg = format!(
-                                "⚠️ **Sell TX Unknown (timeout)**\nPool: `{}`\nTx: `{}`\nPosition reset to Active.",
-                                position.pool, sig_str
-                            );
+                            let discord_msg = i18n::sell_tx_unknown(&position.pool.to_string(), &sig_str);
                             tokio::spawn(async move { notify_discord(&url, &discord_msg).await });
                         }
                     }
@@ -1036,7 +1011,7 @@ pub async fn check_and_sell_positions(
                     s.webhook_url.clone()
                 };
                 if let Some(url) = webhook_url_sell {
-                    let discord_msg = format!("❌ **Sell Send Failed**\nPool: `{}`\n{}", position.pool, err_msg);
+                    let discord_msg = i18n::sell_send_failed(&position.pool.to_string(), &err_msg);
                     tokio::spawn(async move { notify_discord(&url, &discord_msg).await });
                 }
             }
@@ -1124,10 +1099,7 @@ async fn push_error_log_with_webhook(
     // Determine webhook: prefer explicit param, fall back to state.
     let url = webhook_url.as_ref().or(s.webhook_url.as_ref());
     if let Some(url) = url {
-        let discord_msg = format!(
-            "❌ **Error**\nPool: `{}`\nBase Mint: `{}`\n```{}```",
-            pool, base_mint, error_msg
-        );
+        let discord_msg = i18n::error_notify(&pool.to_string(), &base_mint.to_string(), &error_msg);
         let url = url.clone();
         tokio::spawn(async move { notify_discord(&url, &discord_msg).await });
     }
@@ -1541,7 +1513,7 @@ async fn restore_single_position(
         s.push_notification(
             pool_address,
             token_mint,
-            format!("Position restored from wallet: {} tokens, est. value {} lamports", token_amount, current_value),
+            i18n::position_restored(token_amount, current_value),
         );
         s.config.sell_multiplier
     };

--- a/temp-release/trade-app/src/i18n.rs
+++ b/temp-release/trade-app/src/i18n.rs
@@ -1,0 +1,518 @@
+//! Notification message templates with multi-language support.
+//!
+//! Language is selected via the `TRADE_APP_LANG` environment variable.
+//! Supported: `en` (default), `ja`, `zh`, `ru`, `vi`.
+
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lang {
+    En,
+    Ja,
+    Zh,
+    Ru,
+    Vi,
+}
+
+impl Lang {
+    fn parse(raw: &str) -> Self {
+        let s = raw.trim().to_ascii_lowercase();
+        let code = s.split(['_', '-', '.']).next().unwrap_or("");
+        match code {
+            "ja" | "jp" | "jpn" => Lang::Ja,
+            "zh" | "cn" | "chi" | "zho" => Lang::Zh,
+            "ru" | "rus" => Lang::Ru,
+            "vi" | "vn" | "vie" => Lang::Vi,
+            _ => Lang::En,
+        }
+    }
+}
+
+static LANG: OnceLock<Lang> = OnceLock::new();
+
+/// Initialize the global language from the `TRADE_APP_LANG` env var.
+/// Safe to call multiple times — only the first call takes effect.
+pub fn init_from_env() {
+    let lang = std::env::var("TRADE_APP_LANG")
+        .map(|v| Lang::parse(&v))
+        .unwrap_or(Lang::En);
+    let _ = LANG.set(lang);
+    log::info!("Notification language: {:?}", lang);
+}
+
+pub fn lang() -> Lang {
+    *LANG.get().unwrap_or(&Lang::En)
+}
+
+// ─── Templates ───────────────────────────────────────────────────────────────
+
+pub fn pool_qualified_log(pool: &str, base_mint: &str, sol_reserves: f64, ts: &str) -> String {
+    match lang() {
+        Lang::En => format!(
+            "🆕 Pool qualified — Pool: {} | Base Mint: {} | SOL reserves: {:.4} | Time: {}",
+            pool, base_mint, sol_reserves, ts
+        ),
+        Lang::Ja => format!(
+            "🆕 プール検出 — プール: {} | ベースMint: {} | SOL残高: {:.4} | 時刻: {}",
+            pool, base_mint, sol_reserves, ts
+        ),
+        Lang::Zh => format!(
+            "🆕 符合条件的资金池 — 资金池: {} | 基础Mint: {} | SOL储备: {:.4} | 时间: {}",
+            pool, base_mint, sol_reserves, ts
+        ),
+        Lang::Ru => format!(
+            "🆕 Пул подходит — Пул: {} | Base Mint: {} | Резервы SOL: {:.4} | Время: {}",
+            pool, base_mint, sol_reserves, ts
+        ),
+        Lang::Vi => format!(
+            "🆕 Pool đủ điều kiện — Pool: {} | Base Mint: {} | Dự trữ SOL: {:.4} | Thời gian: {}",
+            pool, base_mint, sol_reserves, ts
+        ),
+    }
+}
+
+pub fn pool_qualified_webhook(pool: &str, base_mint: &str, sol_reserves: f64, ts: &str) -> String {
+    match lang() {
+        Lang::En => format!(
+            "🆕 **Pool Qualified for Trade**\n\
+             Pool: `{}`\n\
+             Base Mint: `{}`\n\
+             SOL Reserves: `{:.4} SOL`\n\
+             Timestamp: {}",
+            pool, base_mint, sol_reserves, ts
+        ),
+        Lang::Ja => format!(
+            "🆕 **取引対象プールを検出**\n\
+             プール: `{}`\n\
+             ベースMint: `{}`\n\
+             SOL残高: `{:.4} SOL`\n\
+             時刻: {}",
+            pool, base_mint, sol_reserves, ts
+        ),
+        Lang::Zh => format!(
+            "🆕 **符合交易条件的资金池**\n\
+             资金池: `{}`\n\
+             基础Mint: `{}`\n\
+             SOL储备: `{:.4} SOL`\n\
+             时间戳: {}",
+            pool, base_mint, sol_reserves, ts
+        ),
+        Lang::Ru => format!(
+            "🆕 **Пул подходит для торговли**\n\
+             Пул: `{}`\n\
+             Base Mint: `{}`\n\
+             Резервы SOL: `{:.4} SOL`\n\
+             Время: {}",
+            pool, base_mint, sol_reserves, ts
+        ),
+        Lang::Vi => format!(
+            "🆕 **Pool đủ điều kiện giao dịch**\n\
+             Pool: `{}`\n\
+             Base Mint: `{}`\n\
+             Dự trữ SOL: `{:.4} SOL`\n\
+             Thời gian: {}",
+            pool, base_mint, sol_reserves, ts
+        ),
+    }
+}
+
+pub fn buy_confirmed(
+    pool: &str,
+    base_mint: &str,
+    amount_sol: f64,
+    tokens: u64,
+    tx: &str,
+) -> String {
+    match lang() {
+        Lang::En => format!(
+            "✅ **Buy Confirmed**\n\
+             Pool: `{}`\n\
+             Base Mint: `{}`\n\
+             Amount: `{:.4} SOL`\n\
+             Tokens: `{}`\n\
+             Tx: `{}`",
+            pool, base_mint, amount_sol, tokens, tx
+        ),
+        Lang::Ja => format!(
+            "✅ **購入完了**\n\
+             プール: `{}`\n\
+             ベースMint: `{}`\n\
+             金額: `{:.4} SOL`\n\
+             トークン数: `{}`\n\
+             Tx: `{}`",
+            pool, base_mint, amount_sol, tokens, tx
+        ),
+        Lang::Zh => format!(
+            "✅ **买入已确认**\n\
+             资金池: `{}`\n\
+             基础Mint: `{}`\n\
+             金额: `{:.4} SOL`\n\
+             代币数: `{}`\n\
+             交易: `{}`",
+            pool, base_mint, amount_sol, tokens, tx
+        ),
+        Lang::Ru => format!(
+            "✅ **Покупка подтверждена**\n\
+             Пул: `{}`\n\
+             Base Mint: `{}`\n\
+             Сумма: `{:.4} SOL`\n\
+             Токены: `{}`\n\
+             Tx: `{}`",
+            pool, base_mint, amount_sol, tokens, tx
+        ),
+        Lang::Vi => format!(
+            "✅ **Mua đã xác nhận**\n\
+             Pool: `{}`\n\
+             Base Mint: `{}`\n\
+             Số lượng: `{:.4} SOL`\n\
+             Token: `{}`\n\
+             Tx: `{}`",
+            pool, base_mint, amount_sol, tokens, tx
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn retreat_burn(
+    pool: &str,
+    base_mint: &str,
+    reason: &str,
+    emoji: &str,
+    profit_sign: &str,
+    profit_sol: f64,
+    profit_pct: f64,
+    buy_sol: f64,
+    sell_sol: f64,
+    close_ok: bool,
+) -> String {
+    let (closed_en, closed_ja, closed_zh, closed_ru, closed_vi) = if close_ok {
+        ("Closed ✅", "クローズ済 ✅", "已关闭 ✅", "Закрыто ✅", "Đã đóng ✅")
+    } else {
+        (
+            "Close failed ⚠️",
+            "クローズ失敗 ⚠️",
+            "关闭失败 ⚠️",
+            "Ошибка закрытия ⚠️",
+            "Đóng thất bại ⚠️",
+        )
+    };
+    match lang() {
+        Lang::En => format!(
+            "⚠️ **Retreat Burn**\n\
+             Pool: `{}`\n\
+             Base Mint: `{}`\n\
+             Reason: `{}`\n\
+             {} **{}{:.6} SOL ({}{:.1}%)**\n\
+             Buy: `{:.6} SOL` → Realized: `{:.6} SOL`\n\
+             ATA: {}",
+            pool, base_mint, reason,
+            emoji, profit_sign, profit_sol, profit_sign, profit_pct,
+            buy_sol, sell_sol, closed_en
+        ),
+        Lang::Ja => format!(
+            "⚠️ **強制撤退（バーン）**\n\
+             プール: `{}`\n\
+             ベースMint: `{}`\n\
+             理由: `{}`\n\
+             {} **{}{:.6} SOL ({}{:.1}%)**\n\
+             購入: `{:.6} SOL` → 実現: `{:.6} SOL`\n\
+             ATA: {}",
+            pool, base_mint, reason,
+            emoji, profit_sign, profit_sol, profit_sign, profit_pct,
+            buy_sol, sell_sol, closed_ja
+        ),
+        Lang::Zh => format!(
+            "⚠️ **撤退销毁**\n\
+             资金池: `{}`\n\
+             基础Mint: `{}`\n\
+             原因: `{}`\n\
+             {} **{}{:.6} SOL ({}{:.1}%)**\n\
+             买入: `{:.6} SOL` → 实现: `{:.6} SOL`\n\
+             ATA: {}",
+            pool, base_mint, reason,
+            emoji, profit_sign, profit_sol, profit_sign, profit_pct,
+            buy_sol, sell_sol, closed_zh
+        ),
+        Lang::Ru => format!(
+            "⚠️ **Экстренный выход (burn)**\n\
+             Пул: `{}`\n\
+             Base Mint: `{}`\n\
+             Причина: `{}`\n\
+             {} **{}{:.6} SOL ({}{:.1}%)**\n\
+             Покупка: `{:.6} SOL` → Реализовано: `{:.6} SOL`\n\
+             ATA: {}",
+            pool, base_mint, reason,
+            emoji, profit_sign, profit_sol, profit_sign, profit_pct,
+            buy_sol, sell_sol, closed_ru
+        ),
+        Lang::Vi => format!(
+            "⚠️ **Thoát khẩn cấp (burn)**\n\
+             Pool: `{}`\n\
+             Base Mint: `{}`\n\
+             Lý do: `{}`\n\
+             {} **{}{:.6} SOL ({}{:.1}%)**\n\
+             Mua: `{:.6} SOL` → Đã nhận: `{:.6} SOL`\n\
+             ATA: {}",
+            pool, base_mint, reason,
+            emoji, profit_sign, profit_sol, profit_sign, profit_pct,
+            buy_sol, sell_sol, closed_vi
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn trade_complete(
+    emoji: &str,
+    pool: &str,
+    base_mint: &str,
+    profit_sign: &str,
+    profit_sol: f64,
+    profit_pct: f64,
+    buy_sol: f64,
+    sell_sol: f64,
+    close_ok: bool,
+) -> String {
+    let (closed_en, closed_ja, closed_zh, closed_ru, closed_vi) = if close_ok {
+        ("Closed ✅", "クローズ済 ✅", "已关闭 ✅", "Закрыто ✅", "Đã đóng ✅")
+    } else {
+        (
+            "Close failed ⚠️",
+            "クローズ失敗 ⚠️",
+            "关闭失败 ⚠️",
+            "Ошибка закрытия ⚠️",
+            "Đóng thất bại ⚠️",
+        )
+    };
+    match lang() {
+        Lang::En => format!(
+            "{} **Trade Complete**\n\
+             Pool: `{}`\n\
+             Base Mint: `{}`\n\
+             💰 **{}{:.6} SOL ({}{:.1}%)**\n\
+             Buy: `{:.6} SOL` → Sell: `{:.6} SOL`\n\
+             ATA: {}",
+            emoji, pool, base_mint,
+            profit_sign, profit_sol, profit_sign, profit_pct,
+            buy_sol, sell_sol, closed_en
+        ),
+        Lang::Ja => format!(
+            "{} **取引完了**\n\
+             プール: `{}`\n\
+             ベースMint: `{}`\n\
+             💰 **{}{:.6} SOL ({}{:.1}%)**\n\
+             購入: `{:.6} SOL` → 売却: `{:.6} SOL`\n\
+             ATA: {}",
+            emoji, pool, base_mint,
+            profit_sign, profit_sol, profit_sign, profit_pct,
+            buy_sol, sell_sol, closed_ja
+        ),
+        Lang::Zh => format!(
+            "{} **交易完成**\n\
+             资金池: `{}`\n\
+             基础Mint: `{}`\n\
+             💰 **{}{:.6} SOL ({}{:.1}%)**\n\
+             买入: `{:.6} SOL` → 卖出: `{:.6} SOL`\n\
+             ATA: {}",
+            emoji, pool, base_mint,
+            profit_sign, profit_sol, profit_sign, profit_pct,
+            buy_sol, sell_sol, closed_zh
+        ),
+        Lang::Ru => format!(
+            "{} **Сделка завершена**\n\
+             Пул: `{}`\n\
+             Base Mint: `{}`\n\
+             💰 **{}{:.6} SOL ({}{:.1}%)**\n\
+             Покупка: `{:.6} SOL` → Продажа: `{:.6} SOL`\n\
+             ATA: {}",
+            emoji, pool, base_mint,
+            profit_sign, profit_sol, profit_sign, profit_pct,
+            buy_sol, sell_sol, closed_ru
+        ),
+        Lang::Vi => format!(
+            "{} **Giao dịch hoàn tất**\n\
+             Pool: `{}`\n\
+             Base Mint: `{}`\n\
+             💰 **{}{:.6} SOL ({}{:.1}%)**\n\
+             Mua: `{:.6} SOL` → Bán: `{:.6} SOL`\n\
+             ATA: {}",
+            emoji, pool, base_mint,
+            profit_sign, profit_sol, profit_sign, profit_pct,
+            buy_sol, sell_sol, closed_vi
+        ),
+    }
+}
+
+pub fn sell_failed_onchain(pool: &str, sig: &str) -> String {
+    match lang() {
+        Lang::En => format!(
+            "❌ **Sell Failed (on-chain)**\nPool: `{}`\nTx: `{}`\nPosition reset to Active for retry.",
+            pool, sig
+        ),
+        Lang::Ja => format!(
+            "❌ **売却失敗（オンチェーン）**\nプール: `{}`\nTx: `{}`\nリトライのためポジションをActiveに戻しました。",
+            pool, sig
+        ),
+        Lang::Zh => format!(
+            "❌ **卖出失败（链上）**\n资金池: `{}`\n交易: `{}`\n持仓已重置为Active以便重试。",
+            pool, sig
+        ),
+        Lang::Ru => format!(
+            "❌ **Ошибка продажи (on-chain)**\nПул: `{}`\nTx: `{}`\nПозиция сброшена в Active для повтора.",
+            pool, sig
+        ),
+        Lang::Vi => format!(
+            "❌ **Bán thất bại (on-chain)**\nPool: `{}`\nTx: `{}`\nVị thế được đặt lại Active để thử lại.",
+            pool, sig
+        ),
+    }
+}
+
+pub fn sell_tx_unknown(pool: &str, sig: &str) -> String {
+    match lang() {
+        Lang::En => format!(
+            "⚠️ **Sell TX Unknown (timeout)**\nPool: `{}`\nTx: `{}`\nPosition reset to Active.",
+            pool, sig
+        ),
+        Lang::Ja => format!(
+            "⚠️ **売却TX状態不明（タイムアウト）**\nプール: `{}`\nTx: `{}`\nポジションをActiveに戻しました。",
+            pool, sig
+        ),
+        Lang::Zh => format!(
+            "⚠️ **卖出交易状态未知（超时）**\n资金池: `{}`\n交易: `{}`\n持仓已重置为Active。",
+            pool, sig
+        ),
+        Lang::Ru => format!(
+            "⚠️ **Статус TX продажи неизвестен (таймаут)**\nПул: `{}`\nTx: `{}`\nПозиция сброшена в Active.",
+            pool, sig
+        ),
+        Lang::Vi => format!(
+            "⚠️ **TX bán không rõ (timeout)**\nPool: `{}`\nTx: `{}`\nVị thế được đặt lại Active.",
+            pool, sig
+        ),
+    }
+}
+
+pub fn sell_send_failed(pool: &str, err: &str) -> String {
+    match lang() {
+        Lang::En => format!("❌ **Sell Send Failed**\nPool: `{}`\n{}", pool, err),
+        Lang::Ja => format!("❌ **売却送信失敗**\nプール: `{}`\n{}", pool, err),
+        Lang::Zh => format!("❌ **卖出发送失败**\n资金池: `{}`\n{}", pool, err),
+        Lang::Ru => format!("❌ **Ошибка отправки продажи**\nПул: `{}`\n{}", pool, err),
+        Lang::Vi => format!("❌ **Gửi lệnh bán thất bại**\nPool: `{}`\n{}", pool, err),
+    }
+}
+
+pub fn error_notify(pool: &str, base_mint: &str, err: &str) -> String {
+    match lang() {
+        Lang::En => format!(
+            "❌ **Error**\nPool: `{}`\nBase Mint: `{}`\n```{}```",
+            pool, base_mint, err
+        ),
+        Lang::Ja => format!(
+            "❌ **エラー**\nプール: `{}`\nベースMint: `{}`\n```{}```",
+            pool, base_mint, err
+        ),
+        Lang::Zh => format!(
+            "❌ **错误**\n资金池: `{}`\n基础Mint: `{}`\n```{}```",
+            pool, base_mint, err
+        ),
+        Lang::Ru => format!(
+            "❌ **Ошибка**\nПул: `{}`\nBase Mint: `{}`\n```{}```",
+            pool, base_mint, err
+        ),
+        Lang::Vi => format!(
+            "❌ **Lỗi**\nPool: `{}`\nBase Mint: `{}`\n```{}```",
+            pool, base_mint, err
+        ),
+    }
+}
+
+pub fn position_restored(tokens: u64, est_value_lamports: u64) -> String {
+    match lang() {
+        Lang::En => format!(
+            "Position restored from wallet: {} tokens, est. value {} lamports",
+            tokens, est_value_lamports
+        ),
+        Lang::Ja => format!(
+            "ウォレットからポジションを復元: {} トークン、推定価値 {} lamports",
+            tokens, est_value_lamports
+        ),
+        Lang::Zh => format!(
+            "从钱包恢复持仓: {} 代币，估值 {} lamports",
+            tokens, est_value_lamports
+        ),
+        Lang::Ru => format!(
+            "Позиция восстановлена из кошелька: {} токенов, оценка {} lamports",
+            tokens, est_value_lamports
+        ),
+        Lang::Vi => format!(
+            "Khôi phục vị thế từ ví: {} token, giá trị ước tính {} lamports",
+            tokens, est_value_lamports
+        ),
+    }
+}
+
+pub fn trading_started(wallet: &str, balance_sol: f64, buy_sol: f64, sell_mult: f64) -> String {
+    match lang() {
+        Lang::En => format!(
+            "▶️ Trading started — wallet: {} | balance: {:.4} SOL | buy: {:.4} SOL | sell: {}x",
+            wallet, balance_sol, buy_sol, sell_mult
+        ),
+        Lang::Ja => format!(
+            "▶️ 取引開始 — ウォレット: {} | 残高: {:.4} SOL | 購入額: {:.4} SOL | 売却倍率: {}x",
+            wallet, balance_sol, buy_sol, sell_mult
+        ),
+        Lang::Zh => format!(
+            "▶️ 交易已启动 — 钱包: {} | 余额: {:.4} SOL | 买入: {:.4} SOL | 卖出倍数: {}x",
+            wallet, balance_sol, buy_sol, sell_mult
+        ),
+        Lang::Ru => format!(
+            "▶️ Торговля запущена — кошелёк: {} | баланс: {:.4} SOL | покупка: {:.4} SOL | продажа: {}x",
+            wallet, balance_sol, buy_sol, sell_mult
+        ),
+        Lang::Vi => format!(
+            "▶️ Bắt đầu giao dịch — ví: {} | số dư: {:.4} SOL | mua: {:.4} SOL | bán: {}x",
+            wallet, balance_sol, buy_sol, sell_mult
+        ),
+    }
+}
+
+pub fn trading_stopped(positions: usize) -> String {
+    match lang() {
+        Lang::En => format!("⏹️ Trading stopped — active positions: {}", positions),
+        Lang::Ja => format!("⏹️ 取引停止 — アクティブポジション数: {}", positions),
+        Lang::Zh => format!("⏹️ 交易已停止 — 活跃持仓: {}", positions),
+        Lang::Ru => format!("⏹️ Торговля остановлена — активных позиций: {}", positions),
+        Lang::Vi => format!("⏹️ Dừng giao dịch — vị thế đang mở: {}", positions),
+    }
+}
+
+pub fn grpc_started() -> String {
+    match lang() {
+        Lang::En => "📡 gRPC streaming started — pool detection & notifications active".to_string(),
+        Lang::Ja => "📡 gRPCストリーミング開始 — プール検出と通知が有効です".to_string(),
+        Lang::Zh => "📡 gRPC 流已启动 — 资金池检测与通知已激活".to_string(),
+        Lang::Ru => "📡 gRPC-стриминг запущен — обнаружение пулов и уведомления активны".to_string(),
+        Lang::Vi => "📡 Đã bật gRPC streaming — phát hiện pool và thông báo đang hoạt động".to_string(),
+    }
+}
+
+pub fn grpc_stopped() -> String {
+    match lang() {
+        Lang::En => "⏸️ gRPC streaming stopped — pool detection paused".to_string(),
+        Lang::Ja => "⏸️ gRPCストリーミング停止 — プール検出を一時停止".to_string(),
+        Lang::Zh => "⏸️ gRPC 流已停止 — 资金池检测暂停".to_string(),
+        Lang::Ru => "⏸️ gRPC-стриминг остановлен — обнаружение пулов приостановлено".to_string(),
+        Lang::Vi => "⏸️ Đã dừng gRPC streaming — tạm dừng phát hiện pool".to_string(),
+    }
+}
+
+pub fn trading_already_running() -> String {
+    match lang() {
+        Lang::En => "Trading already running.".to_string(),
+        Lang::Ja => "取引は既に実行中です。".to_string(),
+        Lang::Zh => "交易已在运行。".to_string(),
+        Lang::Ru => "Торговля уже запущена.".to_string(),
+        Lang::Vi => "Giao dịch đã đang chạy.".to_string(),
+    }
+}

--- a/temp-release/trade-app/src/main.rs
+++ b/temp-release/trade-app/src/main.rs
@@ -17,6 +17,7 @@ use tokio::sync::{mpsc, RwLock};
 mod api;
 mod engine;
 mod handlers;
+mod i18n;
 mod runtime;
 mod state;
 mod utils;
@@ -29,6 +30,7 @@ const UPDATE_CHANNEL_CAPACITY: usize = 10_000;
 async fn main() -> Result<(), anyhow::Error> {
     dotenv::dotenv().ok();
     env_logger::init();
+    i18n::init_from_env();
 
     let settings = Settings::from_env()?;
     let config_content = fs::read_to_string(&settings.config_path)?;


### PR DESCRIPTION
## Summary
- Add \`src/i18n.rs\` with notification message templates in 5 languages: English (default), Japanese, Chinese, Russian, Vietnamese.
- Select language via \`TRADE_APP_LANG\` env var at startup (uses a distinct name to avoid clashing with the OS \`LANG\` locale variable). Unknown/unset values fall back to English.
- Refactor all \`format!\`-built Discord webhook and in-memory notification strings in \`engine.rs\` and \`api.rs\` to call typed \`i18n::*\` functions. Covers 14 event templates (pool qualified, buy confirmed, retreat burn, trade complete, sell failures ×3, error, position restored, trading start/stop, gRPC start/stop, already-running).
- Add \`src/bin/notify_test.rs\`: standalone binary that sends all templates to \`WEBHOOK_URL\` for local verification of Discord rendering per language. Run via \`TRADE_APP_LANG=ja cargo run --bin notify-test\`.

Pubkeys, numbers, tx signatures, emoji (🆕✅⚠️❌▶️⏹️📡⏸️🟢🔴💰) and Markdown (\`**bold**\`, \`\`\`code\`\`\`) remain shared across languages — only labels and descriptive phrases are translated. Error message bodies passed through \`error_notify\` / \`sell_send_failed\` are kept English (debug-oriented).

## Test plan
- [x] \`cargo build --bin trade-app\` succeeds
- [x] \`cargo build --bin notify-test\` succeeds
- [x] Verified Discord rendering for all 5 languages via \`notify-test\` (16 messages × 5 langs sent successfully)
- [ ] Reviewer spot-checks translations for correctness
- [ ] Confirm \`TRADE_APP_LANG=ja\` picked up when set in \`.env\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)