### PR TITLE
feat: AUTO_LOOP env to control buy/sell continuation

### DIFF
--- a/temp-release/trade-app/README.md
+++ b/temp-release/trade-app/README.md
@@ -1,5 +1,17 @@
 # Trade App — PumpSwap Auto-Trading Bot
 
+> ## ⚠️ READ THIS FIRST — Risk & Safety Notice
+>
+> This project is **a reference implementation** demonstrating Solana transaction read/write and Geyser gRPC streaming usage. It is provided **as-is, for educational and experimental purposes**.
+>
+> - **No trading happens until you fund the auto-generated `wallet.json`.** The bot is dormant on a zero-balance wallet — sending SOL to it is the explicit opt-in.
+> - **Once trading starts, you can lose your entire deposit.** PumpSwap pools are highly volatile, liquidity can collapse, RPCs can fail, and on-chain conditions change faster than retries can react. Only fund what you can afford to lose.
+> - **`wallet.json` holds your private key.** **Back it up immediately** after first launch and keep at least one offline copy. Anyone with this file controls the funds. We recommend [**SLV Backup**](https://slv.dev/en/doc/backup/quickstart/) for an encrypted, recoverable backup workflow.
+> - **AI tooling (Claude Code, Cursor, etc.) can unintentionally delete or overwrite files**, including `wallet.json`. Always work in version control, keep external backups, and double-check before running destructive commands. **Do not rely solely on the AI's judgment to preserve your wallet.**
+> - This software is licensed under Apache-2.0 — no warranty, no liability. You are responsible for any funds the bot manages.
+
+---
+
 Auto-trading bot for Solana PumpSwap (Pump.fun AMM). Detects new pool creation via Geyser gRPC in real-time and executes the full trade lifecycle: **buy → sell → ATA close** — fully automated.
 
 ## Features
@@ -80,8 +92,12 @@ curl -X POST http://localhost:3000/api/trade/start
 | `WEBHOOK_URL` | | — | Discord Webhook URL |
 | `REDIS_URL` | | — | Redis URL (e.g. `redis://127.0.0.1:6379`) |
 | `CONFIG_PATH` | | `config.jsonc` | Geyser filter config file |
+| `AUTO_LOOP` | | `false` | Keep buying new pools after each cycle. When `false` (default), the bot **stops automatically after one buy/sell cycle completes** so you can review the result before the next run. Accepts `true/1/yes/on` and `false/0/no/off`. |
+| `TRADE_APP_LANG` | | `en` | Notification & log language. Supported: `en`, `ja`, `zh`, `ru`, `vi` (with common aliases like `jp`, `cn`, `vn`). |
 
 > **⚠️ Never commit `.env` or `wallet.json`.** Both are in `.gitignore`.
+>
+> **Back up `wallet.json` to a safe location (offline / encrypted) before funding it.** Losing this file = losing the funds.
 
 ---
 
@@ -98,6 +114,7 @@ curl -X POST http://localhost:3000/api/trade/start
 | `min_pool_sol_lamports` | `100000` (0.0001 SOL) | Minimum pool liquidity to trigger buy |
 | `sell_timeout_secs` | `300` (5 min) | Force exit after this many seconds |
 | `exit_pool_sol_lamports` | `1000000` (0.001 SOL) | Retreat if pool WSOL drops below this |
+| `auto_loop` | `false` | Same as `AUTO_LOOP` env. Live-tunable via `PUT /api/config`. |
 
 ### Configuration Examples
 
@@ -277,11 +294,13 @@ PumpSwap uses reversed naming compared to typical DeFi:
 
 ## Wallet
 
-On first start, `wallet.json` is auto-generated.
+On first start, `wallet.json` is auto-generated as a vanity keypair whose pubkey ends with `SLV` (~0.5–1 s on a modern multi-core CPU).
 
-- **`wallet.json` contains your private key** — keep it secure
-- Fund the displayed pubkey with SOL before starting
-- Minimum required: **0.013 SOL** (buy + ATA rent + fee reserve)
+- **`wallet.json` contains your private key** — keep it secure.
+- **Back it up immediately** before funding. Losing this file = losing the funds. AI tools that touch the working directory may delete or overwrite it; do not rely on the AI to preserve it for you.
+- **Recommended backup tool:** [SLV Backup](https://slv.dev/en/doc/backup/quickstart/) — encrypted, multi-device recovery designed for Solana key material. Run it once after the first launch, then again any time the wallet changes.
+- Fund the displayed pubkey with SOL before starting.
+- Minimum required: **0.013 SOL** (buy + ATA rent + fee reserve).
 
 ---
 

--- a/temp-release/trade-app/src/api.rs
+++ b/temp-release/trade-app/src/api.rs
@@ -157,6 +157,7 @@ pub struct PartialTradeConfig {
     pub min_pool_sol_lamports: Option<u64>,
     pub sell_timeout_secs: Option<u64>,
     pub exit_pool_sol_lamports: Option<u64>,
+    pub auto_loop: Option<bool>,
 }
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -267,6 +268,9 @@ async fn put_config(
     }
     if let Some(v) = body.exit_pool_sol_lamports {
         s.config.exit_pool_sol_lamports = v;
+    }
+    if let Some(v) = body.auto_loop {
+        s.config.auto_loop = v;
     }
     Json(s.config.clone())
 }

--- a/temp-release/trade-app/src/engine.rs
+++ b/temp-release/trade-app/src/engine.rs
@@ -1311,6 +1311,7 @@ async fn mark_position_status(state: &Arc<RwLock<AppState>>, id: &str, status: P
 /// once a buy/sell cycle has fully wound down (no active or selling positions).
 /// Has no effect when `auto_loop` is true or when the bot was already stopped.
 async fn maybe_auto_stop_after_cycle(state: &Arc<RwLock<AppState>>) {
+    let msg = i18n::auto_loop_disabled_stopped();
     let webhook_url = {
         let mut s = state.write().await;
         if !s.running || s.config.auto_loop {
@@ -1320,7 +1321,6 @@ async fn maybe_auto_stop_after_cycle(state: &Arc<RwLock<AppState>>) {
             return;
         }
         s.running = false;
-        let msg = i18n::auto_loop_disabled_stopped();
         s.push_notification(
             solana_sdk::pubkey::Pubkey::default(),
             solana_sdk::pubkey::Pubkey::default(),
@@ -1330,8 +1330,7 @@ async fn maybe_auto_stop_after_cycle(state: &Arc<RwLock<AppState>>) {
         s.webhook_url.clone()
     };
     if let Some(url) = webhook_url {
-        let discord_msg = i18n::auto_loop_disabled_stopped();
-        tokio::spawn(async move { notify_discord(&url, &discord_msg).await });
+        tokio::spawn(async move { notify_discord(&url, &msg).await });
     }
 }
 

--- a/temp-release/trade-app/src/engine.rs
+++ b/temp-release/trade-app/src/engine.rs
@@ -790,6 +790,7 @@ pub async fn check_and_sell_positions(
                 );
                 tokio::spawn(async move { notify_discord(&url, &discord_msg).await });
             }
+            maybe_auto_stop_after_cycle(&state).await;
             continue;
         }
 
@@ -961,6 +962,7 @@ pub async fn check_and_sell_positions(
                                 );
                                 tokio::spawn(async move { notify_discord(&url, &discord_msg).await });
                             }
+                            maybe_auto_stop_after_cycle(&state).await;
                         }
                     }
                     Ok(false) => {
@@ -1305,6 +1307,34 @@ async fn mark_position_status(state: &Arc<RwLock<AppState>>, id: &str, status: P
     }
 }
 
+/// In single-shot mode (`config.auto_loop == false`), set `running = false`
+/// once a buy/sell cycle has fully wound down (no active or selling positions).
+/// Has no effect when `auto_loop` is true or when the bot was already stopped.
+async fn maybe_auto_stop_after_cycle(state: &Arc<RwLock<AppState>>) {
+    let webhook_url = {
+        let mut s = state.write().await;
+        if !s.running || s.config.auto_loop {
+            return;
+        }
+        if s.active_position_count() != 0 {
+            return;
+        }
+        s.running = false;
+        let msg = i18n::auto_loop_disabled_stopped();
+        s.push_notification(
+            solana_sdk::pubkey::Pubkey::default(),
+            solana_sdk::pubkey::Pubkey::default(),
+            msg.clone(),
+        );
+        info!("AUTO_LOOP=false → trading stopped after one buy/sell cycle");
+        s.webhook_url.clone()
+    };
+    if let Some(url) = webhook_url {
+        let discord_msg = i18n::auto_loop_disabled_stopped();
+        tokio::spawn(async move { notify_discord(&url, &discord_msg).await });
+    }
+}
+
 /// WSOL mint address.
 const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
 
@@ -1609,4 +1639,74 @@ async fn restore_single_position(
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod auto_loop_tests {
+    use super::*;
+    use crate::state::{AppState, Position, PositionStatus};
+    use chrono::Utc;
+    use solana_sdk::pubkey::Pubkey;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    fn make_state(auto_loop: bool, running: bool) -> Arc<RwLock<AppState>> {
+        let mut s = AppState::new(None);
+        s.config.auto_loop = auto_loop;
+        s.running = running;
+        Arc::new(RwLock::new(s))
+    }
+
+    fn insert_active_position(s: &mut AppState) {
+        let id = "test-pos".to_string();
+        s.positions.insert(
+            id.clone(),
+            Position {
+                id,
+                pool: Pubkey::new_unique(),
+                base_mint: Pubkey::new_unique(),
+                buy_price_lamports: 100_000,
+                base_amount: 1,
+                bought_at: Utc::now(),
+                status: PositionStatus::Active,
+                total_sell_lamports: 0,
+                quote_token_program: Pubkey::default(),
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn stops_when_auto_loop_off_and_no_positions() {
+        let state = make_state(false, true);
+        maybe_auto_stop_after_cycle(&state).await;
+        assert!(!state.read().await.running, "should auto-stop");
+    }
+
+    #[tokio::test]
+    async fn keeps_running_when_auto_loop_on() {
+        let state = make_state(true, true);
+        maybe_auto_stop_after_cycle(&state).await;
+        assert!(state.read().await.running, "auto_loop=true must keep running");
+    }
+
+    #[tokio::test]
+    async fn keeps_running_when_active_position_remains() {
+        let state = make_state(false, true);
+        {
+            let mut s = state.write().await;
+            insert_active_position(&mut s);
+        }
+        maybe_auto_stop_after_cycle(&state).await;
+        assert!(
+            state.read().await.running,
+            "must wait for all positions to close"
+        );
+    }
+
+    #[tokio::test]
+    async fn noop_when_already_stopped() {
+        let state = make_state(false, false);
+        maybe_auto_stop_after_cycle(&state).await;
+        assert!(!state.read().await.running);
+    }
 }

--- a/temp-release/trade-app/src/i18n.rs
+++ b/temp-release/trade-app/src/i18n.rs
@@ -499,6 +499,16 @@ pub fn trading_stopped(positions: usize) -> String {
     }
 }
 
+pub fn auto_loop_disabled_stopped() -> String {
+    match lang() {
+        Lang::En => "🏁 Single-shot cycle complete — trading stopped (set AUTO_LOOP=true to keep running)".to_string(),
+        Lang::Ja => "🏁 1サイクル完了 — 取引を停止しました (連続実行は AUTO_LOOP=true で有効化)".to_string(),
+        Lang::Zh => "🏁 单次循环已完成 — 交易已停止（设置 AUTO_LOOP=true 以持续运行）".to_string(),
+        Lang::Ru => "🏁 Цикл завершён — торговля остановлена (для продолжения задайте AUTO_LOOP=true)".to_string(),
+        Lang::Vi => "🏁 Hoàn tất một chu kỳ — đã dừng giao dịch (đặt AUTO_LOOP=true để chạy liên tục)".to_string(),
+    }
+}
+
 pub fn grpc_started() -> String {
     match lang() {
         Lang::En => "📡 gRPC streaming started — pool detection & notifications active".to_string(),

--- a/temp-release/trade-app/src/main.rs
+++ b/temp-release/trade-app/src/main.rs
@@ -63,8 +63,10 @@ async fn main() -> Result<(), anyhow::Error> {
         let mut s = AppState::new(settings.webhook_url.clone());
         s.wallet = Some(keypair);
         s.redis_client = redis_client;
+        s.config.auto_loop = settings.auto_loop;
         s
     }));
+    log::info!("AUTO_LOOP = {}", settings.auto_loop);
 
     // Geyser infrastructure
     let transactions_by_slot = create_transactions_by_slot();

--- a/temp-release/trade-app/src/runtime/settings.rs
+++ b/temp-release/trade-app/src/runtime/settings.rs
@@ -62,7 +62,18 @@ impl Settings {
 
         let webhook_url = env::var("WEBHOOK_URL").ok();
         let api_token = env::var("API_TOKEN").ok();
-        let auto_loop = parse_bool_env("AUTO_LOOP").unwrap_or(false);
+        let auto_loop = match parse_bool_env("AUTO_LOOP") {
+            Some(v) => v,
+            None => {
+                if let Ok(raw) = env::var("AUTO_LOOP") {
+                    log::warn!(
+                        "AUTO_LOOP={:?} not recognized as bool — defaulting to false",
+                        raw
+                    );
+                }
+                false
+            }
+        };
 
         Ok(Self {
             config_path,

--- a/temp-release/trade-app/src/runtime/settings.rs
+++ b/temp-release/trade-app/src/runtime/settings.rs
@@ -20,6 +20,9 @@ pub struct Settings {
     pub webhook_url: Option<String>,
     /// Optional Bearer token for API authentication.
     pub api_token: Option<String>,
+    /// When true, keep auto-trading new pools after each buy/sell cycle.
+    /// When false (default), stop after one complete cycle.
+    pub auto_loop: bool,
 }
 
 impl Settings {
@@ -59,6 +62,7 @@ impl Settings {
 
         let webhook_url = env::var("WEBHOOK_URL").ok();
         let api_token = env::var("API_TOKEN").ok();
+        let auto_loop = parse_bool_env("AUTO_LOOP").unwrap_or(false);
 
         Ok(Self {
             config_path,
@@ -69,6 +73,16 @@ impl Settings {
             api_port,
             webhook_url,
             api_token,
+            auto_loop,
         })
+    }
+}
+
+fn parse_bool_env(key: &str) -> Option<bool> {
+    let v = env::var(key).ok()?;
+    match v.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" | "" => Some(false),
+        _ => None,
     }
 }

--- a/temp-release/trade-app/src/state.rs
+++ b/temp-release/trade-app/src/state.rs
@@ -22,6 +22,11 @@ pub struct TradeConfig {
     pub sell_timeout_secs: u64,
     /// If pool WSOL reserves fall to or below this threshold, retreat immediately.
     pub exit_pool_sol_lamports: u64,
+    /// When true, keep buying new pools after each buy/sell cycle.
+    /// When false (default), auto-stop after one full cycle completes
+    /// (buy → sell → ATA close, with no remaining active positions).
+    #[serde(default)]
+    pub auto_loop: bool,
 }
 
 impl Default for TradeConfig {
@@ -34,6 +39,7 @@ impl Default for TradeConfig {
             min_pool_sol_lamports: 100_000, // 0.0001 SOL
             sell_timeout_secs: 300,         // 5 min timeout before retreat
             exit_pool_sol_lamports: 1_000_000, // 0.001 SOL => treat as liquidity collapse
+            auto_loop: false,
         }
     }
 }


### PR DESCRIPTION
## Summary
- New env var **`AUTO_LOOP`** controls whether trade-app keeps trading after a buy/sell cycle finishes.
  - **Default (unset / `false`)**: stop automatically after one complete cycle (buy → sell → ATA close → no active positions).
  - **`true`**: keep buying every newly-detected qualifying pool, as before.
- Exposed as `auto_loop: bool` on `TradeConfig`, so it's also live-tunable via `PUT /api/config`.
- Stop fires after a position transitions to `Closed`/`Sold` **and** `active_position_count() == 0`. Sells already in flight are unaffected (they don't gate on `running`).
- New i18n notification `auto_loop_disabled_stopped` (5 langs) sent to Discord when the auto-stop triggers.

## Why
Previously the bot would buy-sell-buy-sell forever as long as Geyser delivered new `create_pool` events. Operators often want a single-shot run by default, with opt-in to continuous mode.

## Implementation
- `state.rs`: `TradeConfig.auto_loop: bool` (`#[serde(default)]`, default `false`).
- `runtime/settings.rs`: `AUTO_LOOP` env parsed as bool (`true`/`1`/`yes`/`on` → true; unset/empty → false).
- `main.rs`: applies env value to `state.config.auto_loop` at startup; logs the resolved value.
- `api.rs`: `PartialTradeConfig.auto_loop: Option<bool>` so `PUT /api/config` can flip it at runtime.
- `engine.rs`: new `maybe_auto_stop_after_cycle(state)` helper, called from both terminal sites in `check_and_sell_positions`:
  - retreat-burn close (~line 750)
  - normal sell completion + ATA close (~line 932)

## Test plan
- [x] `cargo test --bin trade-app --release` — 5 tests pass (4 new + 1 existing wallet vanity test):
  - `stops_when_auto_loop_off_and_no_positions`
  - `keeps_running_when_auto_loop_on`
  - `keeps_running_when_active_position_remains`
  - `noop_when_already_stopped`
- [ ] Manual smoke test: run with `AUTO_LOOP` unset and confirm bot stops after the first sell completes; run again with `AUTO_LOOP=true` and confirm continuous trading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)